### PR TITLE
Catch all pull exceptions

### DIFF
--- a/pull_data.py
+++ b/pull_data.py
@@ -5,6 +5,7 @@ import datetime
 import APIFunctions
 import Database
 import pytz
+import traceback
 import db_objects as db
 
 
@@ -17,8 +18,13 @@ def pull(session, interval=60, once=False):
         else:
             Logger.log.info('Syncing routes to database')
             routes = [x.name for x in session.query(db.Route).all()]
-            APIFunctions.sync_trips_and_records(routes, session)
-            APIFunctions.sync_predictions(routes, session)
+            try:
+                APIFunctions.sync_trips_and_records(routes, session)
+                APIFunctions.sync_predictions(routes, session)
+            except Exception as e:
+                Logger.log.error('ERROR: Data pull failed, retrying in {} seconds'.format(interval))
+                traceback.print_exc()
+
             if once:
                 break
         time.sleep(interval)


### PR DESCRIPTION
pull_data is failing due to regular API oddities in the middle of the night, this is an error catch-all so that it doesn't terminate. Not expecting this to have any adverse effects on data consistency or day-to-day trip turnover. 
